### PR TITLE
Fix unwanted window border inside tabbed

### DIFF
--- a/bspctab
+++ b/bspctab
@@ -69,6 +69,7 @@ if [ "$focused_class" == "tabbed" ]; then
 	fi
 else
 	if [ "$1" == "inorout" ]; then
+                bspc config -n "$2" border_width 0
                 bspc config -n "$focused" border_width 0
 		tabc add "$2" "$focused"
 		sleep 0.1

--- a/bspctab
+++ b/bspctab
@@ -69,6 +69,7 @@ if [ "$focused_class" == "tabbed" ]; then
 	fi
 else
 	if [ "$1" == "inorout" ]; then
+                bspc config -n "$focused" border_width 0
 		tabc add "$2" "$focused"
 		sleep 0.1
 		tabbed_id="$(printf "%d" $(bspc query -N -n focused))"

--- a/bspctab
+++ b/bspctab
@@ -69,8 +69,8 @@ if [ "$focused_class" == "tabbed" ]; then
 	fi
 else
 	if [ "$1" == "inorout" ]; then
-                bspc config -n "$2" border_width 0
-                bspc config -n "$focused" border_width 0
+		bspc config -n "$2" border_width 0
+		bspc config -n "$focused" border_width 0
 		tabc add "$2" "$focused"
 		sleep 0.1
 		tabbed_id="$(printf "%d" $(bspc query -N -n focused))"


### PR DESCRIPTION
This patch prevents unnecessary window border to be drawn inside tabbed. Doesn't affect the outer border. Border will return when tabbed window splitted out.

Before:
![image](https://github.com/Jaywalker/tabbed-unix-socket-scripts/assets/45139213/7b22c96a-1178-4529-b7d2-ac8ec79ceca4)

After:
![image](https://github.com/Jaywalker/tabbed-unix-socket-scripts/assets/45139213/96e88954-1d04-4c83-b02c-de6b4d48b57b)
