### PR TITLE
Make border only removed on valid tabc move

### DIFF
--- a/bspctab
+++ b/bspctab
@@ -69,9 +69,7 @@ if [ "$focused_class" == "tabbed" ]; then
 	fi
 else
 	if [ "$1" == "inorout" ]; then
-		tabc add "$2" "$focused" &&
-		bspc config -n "$2" border_width 0 &&
-		bspc config -n "$focused" border_width 0
+		tabc add "$2" "$focused"
 		sleep 0.1
 		tabbed_id="$(printf "%d" $(bspc query -N -n focused))"
 		if [ "$2" == "west" ] || [ "$2" == "north" ]; then

--- a/bspctab
+++ b/bspctab
@@ -69,9 +69,9 @@ if [ "$focused_class" == "tabbed" ]; then
 	fi
 else
 	if [ "$1" == "inorout" ]; then
-		bspc config -n "$2" border_width 0
+		tabc add "$2" "$focused" &&
+		bspc config -n "$2" border_width 0 &&
 		bspc config -n "$focused" border_width 0
-		tabc add "$2" "$focused"
 		sleep 0.1
 		tabbed_id="$(printf "%d" $(bspc query -N -n focused))"
 		if [ "$2" == "west" ] || [ "$2" == "north" ]; then

--- a/tabc
+++ b/tabc
@@ -40,6 +40,8 @@ if [ "$cmd" == "add" ]; then
 		exit 1
 	fi
 	if [ "$focused_class" != "tabbed" ]; then
+		bspc config -n "$3" border_width 0
+		bspc config -n "$4" border_width 0
 		otherwin="$tabbedid"
 		tabbed -c &
 		sleep 0.1 # TODO: Fix this

--- a/tabc
+++ b/tabc
@@ -37,7 +37,7 @@ if [ "$cmd" == "add" ]; then
 	focused_class="$(get_class "$tabbedid")"
 	if [ -z "$focused_class" ]; then
 		# Nothing is there.. don't let them create tabs with only one entry
-		exit
+		exit 1
 	fi
 	if [ "$focused_class" != "tabbed" ]; then
 		otherwin="$tabbedid"

--- a/tabc
+++ b/tabc
@@ -40,8 +40,8 @@ if [ "$cmd" == "add" ]; then
 		exit 1
 	fi
 	if [ "$focused_class" != "tabbed" ]; then
+		bspc config -n "$2" border_width 0
 		bspc config -n "$3" border_width 0
-		bspc config -n "$4" border_width 0
 		otherwin="$tabbedid"
 		tabbed -c &
 		sleep 0.1 # TODO: Fix this

--- a/tabc
+++ b/tabc
@@ -41,7 +41,6 @@ if [ "$cmd" == "add" ]; then
 	fi
 	if [ "$focused_class" != "tabbed" ]; then
 		bspc config -n "$2" border_width 0
-		bspc config -n "$3" border_width 0
 		otherwin="$tabbedid"
 		tabbed -c &
 		sleep 0.1 # TODO: Fix this
@@ -52,6 +51,7 @@ fi
 
 case "$cmd" in
 	add)
+		bspc config -n "$3" border_width 0
 		wid="$3"
 		xdotool windowreparent "$wid" "$tabbedid"
 		;;


### PR DESCRIPTION
Previously border will still be removed if window is moved to invalid position (e.g. there is no neighboring window to merge to).